### PR TITLE
feat: check react/preact use for babel plugin

### DIFF
--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -74,10 +74,13 @@ module.exports = () => ({
           {root: ['./src'], alias},
         ]
       : null,
-    [
-      require.resolve('babel-plugin-transform-react-remove-prop-types'),
-      isPreact ? {removeImport: true} : {mode: 'unsafe-wrap'},
-    ],
+    ifAnyDep(
+      ['react', 'preact'],
+      [
+        require.resolve('babel-plugin-transform-react-remove-prop-types'),
+        isPreact ? {removeImport: true} : {mode: 'unsafe-wrap'},
+      ],
+    ),
     isUMD
       ? require.resolve('babel-plugin-transform-inline-environment-variables')
       : null,


### PR DESCRIPTION
Hey Kent,
the idea is simple that we should use `ifAnyDep` check to decide if use babel-plugin-transform-inline-environment-variables, no?

